### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ $ cd $GOPATH/src/github.com/hashicorp/terraform-provider-vault
 $ make build
 ```
 
+This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
+
 Developing the Provider
 ---------------------------
 


### PR DESCRIPTION
I was confused by the `terraform init` output when trying to load this provider from the filesystem mirror. Turned out, everything was wrong and I simply needed a binary  at proper place. There was a missing bit of an info after running `make build` command.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description

Add info about binary location when building the provider, but not developing it.
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

